### PR TITLE
支持Linux下设置壁纸

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -64,6 +64,9 @@ setDesktop = path => {
             err && utools.showNotification(stderr)
         })
     } else {
-        utools.showNotification('不支持 Linux')
+        var script = GetFilePath('set_wallpaper_linux.sh')
+        exec(`bash "${script}" "${path}"`, (err, stdout, stderr) => {
+            err && utools.showNotification(stderr)
+        })
     }
 }

--- a/src/script/set_wallpaper_linux.sh
+++ b/src/script/set_wallpaper_linux.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+bg_path=$1
+
+function set_with_third_part_tools() {
+  if type feh > /dev/null 2>&1; then
+    feh --conversion-timeout 5 --bg-fill -z "$1"
+  elif type nitrogen > /dev/null 2>&1; then
+    nitrogen --set-zoom-fill "$1"
+  fi
+}
+
+# Detect desktop environment
+if [ "$XDG_CURRENT_DESKTOP" = "" ]; then
+  desktop=$(echo "$XDG_DATA_DIRS" | sed 's/.*\(xfce\|kde\|gnome\).*/\1/')
+else
+  desktop=$XDG_CURRENT_DESKTOP
+fi
+desktop=${desktop,,} # convert to lower case
+
+# Set Wallpaper
+case $desktop in
+  # For DDE (Deepin)
+  dde)
+    gsettings set "com.deepin.wrap.gnome.desktop.background picture-uri $bg_path"
+    ;;
+  gnome)
+    # For distributions using Gnome (like Ubuntu)
+    gsettings set "org.gnome.desktop.background picture-uri file:///$bg_path"
+    ;;
+  kde)
+    # For those who useing KDE (like Manjaro)
+    cmd='var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = "org.kde.image";d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");d.writeConfig("Image", "file://'"$bg_path"'/")}'
+    qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$cmd"
+    ;;
+  xfce)
+    xfconf-query --channel xfce4-desktop --property /backdrop/screen0/monitor0/image-path --set "$bg_path"
+    ;;
+  mate)
+    pcmanfm -w "$bg_path"
+    ;;
+  *)
+    # In other WM/DE, detect tools which can set wallpaper automatically.
+    set_with_third_part_tools "$bg_path"
+    ;;
+esac

--- a/src/script/set_wallpaper_linux.sh
+++ b/src/script/set_wallpaper_linux.sh
@@ -12,7 +12,7 @@ function set_with_third_part_tools() {
 
 # Detect desktop environment
 if [ "$XDG_CURRENT_DESKTOP" = "" ]; then
-  desktop=$(echo "$XDG_DATA_DIRS" | sed 's/.*\(xfce\|kde\|gnome\).*/\1/')
+  desktop=$(echo "$XDG_DATA_DIRS" | grep -Eo 'xfce|kde|gnome')
 else
   desktop=$XDG_CURRENT_DESKTOP
 fi
@@ -21,22 +21,22 @@ desktop=${desktop,,} # convert to lower case
 # Set Wallpaper
 case $desktop in
   # For DDE (Deepin)
-  dde)
+  *dde*)
     gsettings set com.deepin.wrap.gnome.desktop.background picture-uri "$bg_path"
     ;;
-  gnome)
+  *gnome*)
     # For distributions using Gnome (like Ubuntu)
     gsettings set org.gnome.desktop.background picture-uri "$bg_path"
     ;;
-  kde)
+  *kde*)
     # For those who useing KDE (like Manjaro)
     cmd='var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = "org.kde.image";d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");d.writeConfig("Image", "file://'"$bg_path"'/")}'
     qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$cmd"
     ;;
-  xfce)
+  *xfce*)
     xfconf-query --channel xfce4-desktop --property /backdrop/screen0/monitor0/image-path --set "$bg_path"
     ;;
-  mate)
+  *mate*)
     pcmanfm -w "$bg_path"
     ;;
   *)

--- a/src/script/set_wallpaper_linux.sh
+++ b/src/script/set_wallpaper_linux.sh
@@ -22,11 +22,11 @@ desktop=${desktop,,} # convert to lower case
 case $desktop in
   # For DDE (Deepin)
   dde)
-    gsettings set "com.deepin.wrap.gnome.desktop.background picture-uri $bg_path"
+    gsettings set com.deepin.wrap.gnome.desktop.background picture-uri "$bg_path"
     ;;
   gnome)
     # For distributions using Gnome (like Ubuntu)
-    gsettings set "org.gnome.desktop.background picture-uri file:///$bg_path"
+    gsettings set org.gnome.desktop.background picture-uri "$bg_path"
     ;;
   kde)
     # For those who useing KDE (like Manjaro)


### PR DESCRIPTION
在 script 下增加一个脚本 `set_wallpaper_linux.sh`, 根据所使用的桌面环境设置壁纸

目前在 Ubuntu, Deepin, ArchLinux (KDE / i3WM) 下进行了测试, 应该可以覆盖大部分桌面环境